### PR TITLE
avoid branching in naked _start function

### DIFF
--- a/libgloss/patmos/crt0.c
+++ b/libgloss/patmos/crt0.c
@@ -99,6 +99,7 @@ void _start()
   int stack_size =
     (unsigned)&_stack_cache_base - (unsigned)&_shadow_stack_base;
 
+  // make sure to have a positive stack size
   // workaround for -O0: avoid branch, perform abs(stack_size) via bit twiddling
   int const mask = stack_size >> sizeof(int) * 8 - 1;
   stack_size = (stack_size + mask) ^ mask;


### PR DESCRIPTION
It is a known issue that C code in naked function will not always compile, especially at -O0. _start does not compile at -O0 because of a branch, which needs to be if-converted using the -simplifycfg optimization. If we want _start to compile at -O0, the branch can be replaced with bit manipulation.
