### PR TITLE
libgloss: _open is called by newlib/libc as variadic function.

### DIFF
--- a/libgloss/patmos/open.c
+++ b/libgloss/patmos/open.c
@@ -29,15 +29,22 @@
 //   policies, either expressed or implied, of the copyright holder.
     
 #include <errno.h>
+#include <stdarg.h>
 
 #undef errno
 extern int  errno;
 
 //******************************************************************************
 /// _open - open a file.
-int _open(const char *name, int flags, int mode)
+int _open(const char *name, int flags, ...)
 {
+  va_list args;
+  va_start(args, flags);
+  // TODO: access mode as first vararg (possibly)
   // TODO: implement for simulator target
+
   errno  = ENOSYS;
+  
+  va_end(args);
   return -1;
 }


### PR DESCRIPTION
As seen in `newlib/libc/include/sys/_default_fcntl.h` the system calls the function _open as variadic function.
Therefore access to the parameters in _open are off.