### PR TITLE
patmos-plug: Added lazy linking plug capabilities for newlib

### DIFF
--- a/libgloss/patmos/close.c
+++ b/libgloss/patmos/close.c
@@ -34,10 +34,19 @@
 extern int  errno;
 
 //******************************************************************************
+/// patmos-plug: close: stub called if 'patmosplug_close(int)' is not defined.
+int _patmosplug_close(int file) {
+  errno = EBADF;
+  return -1;
+}
+
+int patmosplug_close(int file)
+    __attribute__((weak, alias("_patmosplug_close")));
+
+//******************************************************************************
 /// _close - close a file descriptor.
 int _close(int file)
 {
   // TODO: implement for simulator target
-  errno  = EBADF;
-  return -1;
+  return patmosplug_close(file);
 }

--- a/libgloss/patmos/close.c
+++ b/libgloss/patmos/close.c
@@ -34,15 +34,16 @@
 extern int  errno;
 
 //******************************************************************************
-/// patmos-plug: close: Implements the default `_close` implementation used when no specific 
-/// implementation is provided at link time.
-///  It is called if 'patmosplug_close(int)' is not defined.
+/// patmos-plug: close: Implements the default `_close` implementation used when
+/// no specific implementation is provided at link time.
+/// Called if `patmosplug_close(int)` is not defined.
 int _patmosplug_close(int file) {
+  // TODO: implement for simulator target
   errno = EBADF;
   return -1;
 }
-/// patmosplug_clone: Alternative, patmos-specific `_close` implementation that can be provided
-/// at program link time.
+/// patmosplug_close: Alternative, patmos-specific `_close` implementation that
+/// can be provided at program link time.
 /// If not provided, will default to calling `_patmosplug_close`.
 int patmosplug_close(int file)
     __attribute__((weak, alias("_patmosplug_close")));
@@ -51,6 +52,5 @@ int patmosplug_close(int file)
 /// _close - close a file descriptor.
 int _close(int file)
 {
-  // TODO: implement for simulator target
   return patmosplug_close(file);
 }

--- a/libgloss/patmos/close.c
+++ b/libgloss/patmos/close.c
@@ -41,7 +41,9 @@ int _patmosplug_close(int file) {
   errno = EBADF;
   return -1;
 }
-
+/// patmosplug_clone: Alternative, patmos-specific `_close` implementation that can be provided
+/// at program link time.
+/// If not provided, will default to calling `_patmosplug_close`.
 int patmosplug_close(int file)
     __attribute__((weak, alias("_patmosplug_close")));
 

--- a/libgloss/patmos/close.c
+++ b/libgloss/patmos/close.c
@@ -34,7 +34,9 @@
 extern int  errno;
 
 //******************************************************************************
-/// patmos-plug: close: stub called if 'patmosplug_close(int)' is not defined.
+/// patmos-plug: close: Implements the default `_close` implementation used when no specific 
+/// implementation is provided at link time.
+///  It is called if 'patmosplug_close(int)' is not defined.
 int _patmosplug_close(int file) {
   errno = EBADF;
   return -1;

--- a/libgloss/patmos/open.c
+++ b/libgloss/patmos/open.c
@@ -35,18 +35,25 @@
 extern int  errno;
 
 //******************************************************************************
-/// patmos-plug: open: stub called if 'patmosplug_open(const char *, int, int)'
-/// is not defined.
+/// patmos-plug: open: Implements the default `_open` implementation used when
+/// no specific implementation is provided at link time.
+/// Called if `patmosplug_open(const char *, int, int)` is not defined.
 int _patmosplug_open(const char *name, int flags, int mode) {
   errno = ENOSYS;
   return -1;
 }
 
+/// patmosplug_open: Alternative, patmos-specific `_open` implementation that
+/// can be provided at program link time.
+/// If not provided, will default to calling `_patmosplug_open`.
 int patmosplug_open(const char *name, int flags, int mode)
     __attribute__((weak, alias("_patmosplug_open")));
 
 //******************************************************************************
 /// _open - open a file.
+/// 24-12-2020: Changed to varargs, as newlibc will be compiled expecting a
+/// platform specific `_open` function with varargs.
+/// See `newlib/libc/include/sys/_default_fcntl.h`
 int _open(const char *name, int flags, ...)
 {
   va_list args;

--- a/libgloss/patmos/open.c
+++ b/libgloss/patmos/open.c
@@ -35,16 +35,29 @@
 extern int  errno;
 
 //******************************************************************************
+/// patmos-plug: open: stub called if 'patmosplug_open(const char *, int, int)'
+/// is not defined.
+int _patmosplug_open(const char *name, int flags, int mode) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int patmosplug_open(const char *name, int flags, int mode)
+    __attribute__((weak, alias("_patmosplug_open")));
+
+//******************************************************************************
 /// _open - open a file.
 int _open(const char *name, int flags, ...)
 {
   va_list args;
+  int mode, errorcode;
   va_start(args, flags);
-  // TODO: access mode as first vararg (possibly)
-  // TODO: implement for simulator target
 
-  errno  = ENOSYS;
+  mode = va_arg(args, int);
   
+  /* execute patmos-plugin implementation */
+  errorcode = patmosplug_open(name, flags, mode);
+
   va_end(args);
-  return -1;
+  return errorcode;
 }

--- a/libgloss/patmos/open.c
+++ b/libgloss/patmos/open.c
@@ -29,15 +29,22 @@
 //   policies, either expressed or implied, of the copyright holder.
     
 #include <errno.h>
+#include <stdarg.h>
 
 #undef errno
 extern int  errno;
 
 //******************************************************************************
 /// _open - open a file.
-int _open(const char *name, int flags, int mode)
+int _open(const char *name, int flags, ...)
 {
+  va_list args;
+  va_start(args, flags);
+  // TODO: access mode as first vararg (possibly)
   // TODO: implement for simulator target
+
   errno  = ENOSYS;
+  
+  va_end(args);
   return -1;
 }

--- a/libgloss/patmos/read.c
+++ b/libgloss/patmos/read.c
@@ -39,13 +39,18 @@ extern int  errno;
 extern int  __patmos_stdin_offset;
 
 //******************************************************************************
-/// patmos-plug: read: stub called if 'patmosplug_read(int, char *, int)' is not
-/// defined.
+/// patmos-plug: read: Implements the default `_read` implementation used when
+/// no specific implementation is provided at link time.
+/// Called if `patmosplug_read(int)` is not defined.
 int _patmosplug_read(int file, char *buf, int len) {
+  // TODO: implement for simulator target
   errno = EBADF;
   return -1;
 }
 
+/// patmosplug_read: Alternative, patmos-specific `_read` implementation that
+/// can be provided at program link time.
+/// If not provided, will default to calling `_patmosplug_read`.
 int patmosplug_read(int file, char *buf, int len)
     __attribute__((weak, alias("_patmosplug_read")));
 
@@ -103,6 +108,5 @@ int _read(int file, char *buf, int len)
     return i;
   }
 
-  // TODO: implement for simulator target
   return patmosplug_read(file, buf, len);
 }

--- a/libgloss/patmos/read.c
+++ b/libgloss/patmos/read.c
@@ -39,6 +39,17 @@ extern int  errno;
 extern int  __patmos_stdin_offset;
 
 //******************************************************************************
+/// patmos-plug: read: stub called if 'patmosplug_read(int, char *, int)' is not
+/// defined.
+int _patmosplug_read(int file, char *buf, int len) {
+  errno = EBADF;
+  return -1;
+}
+
+int patmosplug_read(int file, char *buf, int len)
+    __attribute__((weak, alias("_patmosplug_read")));
+
+//******************************************************************************
 /// _read - read a file descriptor.
 int _read(int file, char *buf, int len)
 {
@@ -93,6 +104,5 @@ int _read(int file, char *buf, int len)
   }
 
   // TODO: implement for simulator target
-  errno = EBADF;
-  return -1;
+  return patmosplug_read(file, buf, len);
 }

--- a/libgloss/patmos/write.c
+++ b/libgloss/patmos/write.c
@@ -36,13 +36,18 @@
 extern int  errno;
 
 //******************************************************************************
-/// patmos-plug: write: stub called if 'patmosplug_write(int, char *, int)' is
-/// not defined.
+/// patmos-plug: close: Implements the default `_write` implementation used when
+/// no specific implementation is provided at link time.
+/// Called if `patmosplug_write(int, char *, int)` is not defined.
 int _patmosplug_write(int file, char *buf, int nbytes) {
+  // TODO: implement for simulator target
   errno = EBADF;
   return -1;
 }
 
+/// patmosplug_write: Alternative, patmos-specific `_write` implementation that
+/// can be provided at program link time.
+/// If not provided, will default to calling `_patmosplug_write`.
 int patmosplug_write(int file, char *buf, int nbytes)
     __attribute__((weak, alias("_patmosplug_write")));
 
@@ -82,6 +87,5 @@ int _write(int file, char *buf, int nbytes)
     return nbytes;
   }
 
-  // TODO: implement for simulator target
   return patmosplug_write(file, buf, nbytes);
 }

--- a/libgloss/patmos/write.c
+++ b/libgloss/patmos/write.c
@@ -35,6 +35,16 @@
 #undef errno
 extern int  errno;
 
+//******************************************************************************
+/// patmos-plug: write: stub called if 'patmosplug_write(int, char *, int)' is
+/// not defined.
+int _patmosplug_write(int file, char *buf, int nbytes) {
+  errno = EBADF;
+  return -1;
+}
+
+int patmosplug_write(int file, char *buf, int nbytes)
+    __attribute__((weak, alias("_patmosplug_write")));
 
 //******************************************************************************
 /// _write - write to a file descriptor.
@@ -73,6 +83,5 @@ int _write(int file, char *buf, int nbytes)
   }
 
   // TODO: implement for simulator target
-  errno  = EBADF;
-  return -1;
+  return patmosplug_write(file, buf, nbytes);
 }


### PR DESCRIPTION
### Problem
While implementing a filesystem driver it became apparent that in order to use the POSIX based API, especially the library functions `open(2)`, `read(2)`, `write(2)`, `close(2)`, either of the following compromises has to be made:
- Compiling and linking the driver into newlib.
- Using preprocessor macros to enable a choice if the driver is built inside newlib.
- Factor out all functionality into separate libraries.

Whilst infeasible, the last option would have been the preferred one from an architectural point of view, as we believe that libc should be agnostic things like filesystem implementations. Furthermore, `read(2)` and `write(2)` is already implemented to handle standard io streams over `UART`.

### Purposed solution
Our solution allows newlib to not include any filesystem dependent code at all. Therefore `newlib/libgloss` is extended with weak symbols as well as basic stub functions. This allows overwriting functionality with user-code in the linking stage if it is available, keeping newlib backwards compatible and environment agnostic.